### PR TITLE
#8 numeric sender with more than 11 characters throws exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5</version>
+            <version>4.5.1</version>
         </dependency>
     </dependencies>
     <licenses>

--- a/src/main/java/com/Spryng/SpryngJavaSDK/Constants.java
+++ b/src/main/java/com/Spryng/SpryngJavaSDK/Constants.java
@@ -66,7 +66,12 @@ public interface Constants
     public final int REFERENCE_MAX_LENGTH = 256;
 
     /**
-     * The maximum length of the `sender` parameter.
+     * The maximum length of the `sender` parameter with alphanumeric values.
      */
-    public final int SENDER_MAX_LENGTH = 11;
+    public final int SENDER_ALPHANUMERIC_MAX_LENGTH = 11;
+    
+    /**
+     * The maximum length of the `sender` parameter with only numeric values.
+     */
+    public final int SENDER_NUMERIC_MAX_LENGTH = 14;
 }

--- a/src/main/java/com/Spryng/SpryngJavaSDK/Spryng.java
+++ b/src/main/java/com/Spryng/SpryngJavaSDK/Spryng.java
@@ -51,11 +51,18 @@ public class Spryng implements Constants
     }
 
     public void setSender(String sender) throws SpryngException
-    {
-        if (sender.length() > SENDER_MAX_LENGTH)
-        {
-            throw new SpryngException("The Sender ID you provided is too long. The maximum length is: " + SENDER_MAX_LENGTH);
-        }
+    {   	
+    		if (sender == null)
+    			throw new SpryngException("The Sender ID is required");
+    
+    		if (sender.matches("^[0-9]+$"))
+    			{
+    				if (sender.length() > SENDER_NUMERIC_MAX_LENGTH) 
+    					throw new SpryngException("The numeric Sender ID you provided is too long. The maximum length is: " + SENDER_NUMERIC_MAX_LENGTH);
+    			}
+        		else if (sender.length() > SENDER_ALPHANUMERIC_MAX_LENGTH)
+                throw new SpryngException("The alphanumeric Sender ID you provided is too long. The maximum length is: " + SENDER_ALPHANUMERIC_MAX_LENGTH);
+            
         this.sender = sender;
     }
 

--- a/src/test/java/com/Spryng/SpryngJavaSDK/SpryngTest.java
+++ b/src/test/java/com/Spryng/SpryngJavaSDK/SpryngTest.java
@@ -27,4 +27,42 @@ public class SpryngTest extends TestCase
     {
         assertEquals(this.spryng.getClass(), Spryng.class);
     }
+    
+    @Test
+    public void testSenderValidation()
+    {
+       	try {
+    				this.spryng.setSender(null);
+    				fail("Null sender should throw an exception");
+    		} catch (SpryngException e) {
+    				assertTrue(e.getMessage().contains("The Sender ID is required"));
+    		}
+    	
+    	
+    		try {
+				this.spryng.setSender("ABCDEFGH123");
+		} catch (SpryngException e) {
+				fail("11 character alphanumeric sender should not throw an exception");
+		}
+    		
+       	try {
+    				this.spryng.setSender("ABCDEFGH12345");
+    				fail("13 character alphanumeric sender should throw an exception");
+    		} catch (SpryngException e) {
+    				assertTrue(e.getMessage().contains("The alphanumeric Sender ID you provided is too long"));
+    		}
+       	
+		try {
+			this.spryng.setSender("12345678901234");
+		} catch (SpryngException e) {
+			fail("14 character numeric sender should not throw an exception");
+		}
+		
+      	try {
+			this.spryng.setSender("123456789012345");
+			fail("15 character numeric sender should throw an exception");
+      	} catch (SpryngException e) {
+			assertTrue(e.getMessage().contains("The numeric Sender ID you provided is too long"));
+      	}
+    }
 }


### PR DESCRIPTION
Fix for issue #8 